### PR TITLE
gpt4 : remove useless giving of name to gpt4

### DIFF
--- a/freeGPT/gpt4.py
+++ b/freeGPT/gpt4.py
@@ -34,7 +34,7 @@ class Completion:
                         "messages": [
                             {
                                 "role": "system",
-                                "content": "You are Ava, an AI assistant. You are running on GPT-4 by OpenAI.",
+                                "content": "You are GPT-4 by OpenAI.",
                             },
                             {"role": "user", "content": prompt},
                         ],


### PR DESCRIPTION
theres no need to give it a name, all it needs to know at max ( even if that ) is that its gpt4 for some weird usecases, but thats beside the point, anyway i removed useless naming of the gpt4 bot :)