### PR TITLE
edit gpt4 script

### DIFF
--- a/freeGPT/gpt4.py
+++ b/freeGPT/gpt4.py
@@ -10,7 +10,7 @@ try:
     import tls_client
 except ModuleNotFoundError:
     system("pip install tls_client --no-cache-dir")
-
+    import tls_client
 
 class Completion:
     """


### PR DESCRIPTION
There was a typo in gpt4.py file which was forgetting to add `import tls_client` after installing tls_client (line 12).